### PR TITLE
update backend url

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -47,7 +47,7 @@ export default {
   // Axios module configuration: https://go.nuxtjs.dev/config-axios
   axios: {
     // Workaround to avoid enforcing hard-coded localhost:3000: https://github.com/nuxt-community/axios-module/issues/308
-    baseURL: "https://memebookv1.herokuapp.com/api/v1/",
+    baseURL: "https://memebook-r4vf.onrender.com/api/v1/",
   },
 
   toast: {


### PR DESCRIPTION
Backend service moved from heroku to render.
Update the new url :- https://memebook-r4vf.onrender.com/api/v1/